### PR TITLE
Fix rust build scripts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Create vender
+      - name: Create vendor
         run: cargo vendor
       - name: Set configuration
         run: |
           mkdir .cargo && touch .cargo/.config
-          mv build-aux/cargo_offline_config .cargo/config 
+          mv build-aux/cargo_offline_config .cargo/config
       - name: Create package
         run: |
          touch flatpak.tar
          tar --exclude=flatpak.tar -czvf flatpak.tar .
-        
+
       - uses: actions/upload-artifact@v2
         with:
           name: flatpak_build

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /build-dir
 /.flatpak-builder
 /_buildir
+/vendor
+/build
 /build-aux/.*
 data/gschemas.compiled
 data/com.gigitux.youp.gresource

--- a/build-aux/cargo.sh
+++ b/build-aux/cargo.sh
@@ -9,10 +9,10 @@ export BUILDTYPE="$4"
 export APP_BIN="$5"
 
 
-if [[ $BUILDTYPE = "release" ]]
+if [ $BUILDTYPE = "release" ]
 then
     echo "RELEASE MODE"
-    cargo --offline --locked build --release --manifest-path \
+    cargo build --release --manifest-path \
         "$MESON_SOURCE_ROOT"/Cargo.toml && \
         cp "$CARGO_TARGET_DIR"/release/"$APP_BIN" "$OUTPUT"
 else

--- a/build-aux/cargo.sh
+++ b/build-aux/cargo.sh
@@ -12,7 +12,7 @@ export APP_BIN="$5"
 if [ $BUILDTYPE = "release" ]
 then
     echo "RELEASE MODE"
-    cargo build --release --manifest-path \
+    cargo build --locked --release --manifest-path \
         "$MESON_SOURCE_ROOT"/Cargo.toml && \
         cp "$CARGO_TARGET_DIR"/release/"$APP_BIN" "$OUTPUT"
 else

--- a/build-aux/cargo.sh
+++ b/build-aux/cargo.sh
@@ -9,7 +9,13 @@ export BUILDTYPE="$4"
 export APP_BIN="$5"
 
 
-if [ $BUILDTYPE = "release" ]
+if [ $IS_FLATPAK ]
+then
+    echo "FLATPAK MODE"
+    cargo build --locked --offline --release --manifest-path \
+        "$MESON_SOURCE_ROOT"/Cargo.toml && \
+        cp "$CARGO_TARGET_DIR"/release/"$APP_BIN" "$OUTPUT"
+elif [ $BUILDTYPE = "release" ]
 then
     echo "RELEASE MODE"
     cargo build --locked --release --manifest-path \

--- a/build-aux/com.gigitux.youp.json
+++ b/build-aux/com.gigitux.youp.json
@@ -20,6 +20,7 @@
     "append-path": "/usr/lib/sdk/rust-stable/bin",
     "build-args": ["--share=network"],
     "env": {
+      "IS_FLATPAK": "1",
       "RUSTFLAGS": "--remap-path-prefix =../",
       "CARGO_HOME": "/run/build/youp/cargo"
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,20 @@
 sources = [
     'main.rs',
+    'controllers/ui.rs',
+    'controllers/settings.rs',
+    'controllers/about.rs',
+    'controllers/mod.rs',
+    'controllers/indicator.rs',
+    'controllers/headbar.rs',
+    'models/applications.rs',
+    'models/constants.rs',
+    'models/mod.rs',
+    'views/ui.rs',
+    'views/settings.rs',
+    'views/mod.rs',
+    'views/indicator.rs',
+    'views/webview.rs',
+    'views/headbar.rs'
 ]
 
 cargo_script = find_program(join_paths(meson.source_root(), 'build-aux/cargo.sh'))


### PR DESCRIPTION
I noticed some three minor issues with the build scripts. 

First, `cargo.sh` uses [[ even though that is a bash command. I guess you have linked `/bin/sh` to `/bin/bash` on your machine? It's not the cases for me and, as a result, it always builds in debug mode.

Second, I added all source files to `src/meson.build` so changes in the rust code actually cause a re-build.

Third, I removed the `--offline`-flag rom the release build. That causes problems when you build in release mode on a fresh checkout. 