### PR TITLE
Add linter to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,14 +10,23 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  create-package:
+  ci:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install dependencies
+        run: sudo apt install -y build-essential libgtk-3-dev libwebkit2gtk-4.0-dev
+
       - name: Linting
         run: cargo clippy
+
+  create-package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
 
       - name: Create vendor
         run: cargo vendor

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,12 +15,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Linting
+        run: cargo clippy
+
       - name: Create vendor
         run: cargo vendor
+
       - name: Set configuration
         run: |
           mkdir .cargo && touch .cargo/.config
           mv build-aux/cargo_offline_config .cargo/config
+
       - name: Create package
         run: |
          touch flatpak.tar

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,14 +10,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  ci:
+  continuous-integration:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: sudo apt install -y build-essential libgtk-3-dev libwebkit2gtk-4.0-dev
+        run: sudo apt install -y build-essential libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev
 
       - name: Linting
         run: cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ features = ["v3_16"]
 [dependencies.gio]
 version = "0.9.1"
 features = ["v2_44"]
+
 [dependencies.webkit2gtk]
 version= "0.11.0"
 features= ["v2_16"]

--- a/src/controllers/headbar.rs
+++ b/src/controllers/headbar.rs
@@ -26,28 +26,20 @@ fn set_theme(
     is_dark_mode_enabled: bool,
 ) {
     if is_dark_mode_enabled {
-        match custom_settings.set_boolean("dark-theme", true) {
-            Ok(_) => {
-                general_settings.set_property_gtk_application_prefer_dark_theme(true);
-                web_view.run_javascript(
-                    "document.body.classList.add('dark')",
-                    None::<&gio::Cancellable>,
-                    |_result| {},
-                );
-            }
-            Err(_) => {}
+        if custom_settings.set_boolean("dark-theme", true).is_ok() {
+            general_settings.set_property_gtk_application_prefer_dark_theme(true);
+            web_view.run_javascript(
+                "document.body.classList.add('dark')",
+                None::<&gio::Cancellable>,
+                |_result| {},
+            );
         }
-    } else {
-        match custom_settings.set_boolean("dark-theme", false) {
-            Ok(_) => {
-                general_settings.set_property_gtk_application_prefer_dark_theme(false);
-                web_view.run_javascript(
-                    "document.body.classList.remove('dark')",
-                    None::<&gio::Cancellable>,
-                    |_result| {},
-                );
-            }
-            Err(_) => {}
-        }
+    } else if custom_settings.set_boolean("dark-theme", false).is_ok() {
+        general_settings.set_property_gtk_application_prefer_dark_theme(false);
+        web_view.run_javascript(
+            "document.body.classList.remove('dark')",
+            None::<&gio::Cancellable>,
+            |_result| {},
+        );
     }
 }

--- a/src/controllers/indicator.rs
+++ b/src/controllers/indicator.rs
@@ -7,7 +7,7 @@ pub fn set_status_indicator(
     let title_tab = web_view
         .get_title()
         .map(move |title| title.to_string())
-        .unwrap_or_else(|| String::new());
+        .unwrap_or_else(String::new);
 
     match title_tab.chars().any(|char| char.is_numeric()) {
         true => app_indicator

--- a/src/controllers/settings.rs
+++ b/src/controllers/settings.rs
@@ -9,41 +9,33 @@ pub fn toogle_full_screen(
     is_full_screen_enabled: bool,
 ) {
     if is_full_screen_enabled {
-        match custom_settings.set_boolean("full-screen", true) {
-            Ok(_) => {
-                web_view.run_javascript(
-                    "
-                    var head = document.head || document.getElementsByTagName('head')[0];
-                    var style = document.createElement('style');            
-                    style.type = 'text/css';
-                    style.id = 'gtkwhats';
-                    var css = '._36Q2N {width: 100vw !important}';
-                    // Append the css rules to the style node
-                    style.appendChild(document.createTextNode(css));
-                    
-                    // Append the style node to the head of the page
-                    head.appendChild(style); 
-                    ",
-                    None::<&gio::Cancellable>,
-                    |_result| {},
-                );
-            }
-            Err(_) => {}
+        if custom_settings.set_boolean("full-screen", true).is_ok() {
+            web_view.run_javascript(
+                "
+                var head = document.head || document.getElementsByTagName('head')[0];
+                var style = document.createElement('style');            
+                style.type = 'text/css';
+                style.id = 'gtkwhats';
+                var css = '._36Q2N {width: 100vw !important}';
+                // Append the css rules to the style node
+                style.appendChild(document.createTextNode(css));
+                
+                // Append the style node to the head of the page
+                head.appendChild(style); 
+                ",
+                None::<&gio::Cancellable>,
+                |_result| {},
+            );
         }
-    } else {
-        match custom_settings.set_boolean("full-screen", false) {
-            Ok(_) => {
-                web_view.run_javascript(
-                    r##"
-                    var elms = document.querySelectorAll('[id="gtkwhats"]');
-                    elms.forEach((e) => e.remove());
-                   "##,
-                    None::<&gio::Cancellable>,
-                    |_result| {},
-                );
-            }
-            Err(_) => {}
-        }
+    } else if custom_settings.set_boolean("full-screen", false).is_ok() {
+        web_view.run_javascript(
+            r##"
+            var elms = document.querySelectorAll('[id="gtkwhats"]');
+            elms.forEach((e) => e.remove());
+           "##,
+            None::<&gio::Cancellable>,
+            |_result| {},
+        );
     }
 }
 
@@ -56,15 +48,9 @@ pub fn toggle_tray_icon(is_tray_icon_enabled: bool, custom_settings: &GSettings)
 }
 
 fn disable_tray_icon(custom_settings: &GSettings) {
-    match custom_settings.set_boolean("tray-icon", false) {
-        Ok(_) => {}
-        Err(_) => {}
-    }
+    let _ = custom_settings.set_boolean("tray-icon", false);
 }
 
 fn enable_tray_icon(custom_settings: &GSettings) {
-    match custom_settings.set_boolean("tray-icon", true) {
-        Ok(_) => {}
-        Err(_) => {}
-    }
+    let _ = custom_settings.set_boolean("tray-icon", true);
 }

--- a/src/views/ui.rs
+++ b/src/views/ui.rs
@@ -50,7 +50,7 @@ pub fn build_ui(application: &Application) {
     webview.connect_show_notification(clone!(@strong application => move |_, notification| {
 
         notification.connect_clicked(clone!(@strong application => move |_| {
-            &application.present();
+            application.present();
         }));
 
         false
@@ -73,5 +73,5 @@ pub fn build_ui(application: &Application) {
 }
 
 fn get_settings() -> Settings {
-    return Settings::get_default().unwrap();
+    Settings::get_default().unwrap()
 }

--- a/src/views/webview.rs
+++ b/src/views/webview.rs
@@ -41,13 +41,15 @@ pub fn create_webview(general_settings: &Settings, custom_settings: &GSettings) 
                     .clone()
                     .downcast::<NavigationPolicyDecision>()
                     .expect("Unable to cast policy");
-                let url = policy.get_request().unwrap().get_uri().unwrap();
+                let url = policy.get_navigation_action().unwrap()
+                        .get_request().unwrap().get_uri().unwrap();
 
                 match show_uri(Screen::get_default().as_ref(), url.as_str(), 0) {
                     Ok(action) => action,
                     Err(_) => panic!("Error to open this url: {:?}", url),
                 }
-                return true;
+
+                true
             }
 
             PolicyDecisionType::NavigationAction => true,
@@ -67,5 +69,5 @@ pub fn create_webview(general_settings: &Settings, custom_settings: &GSettings) 
         }),
     );
 
-    CustomWebView { webview: webview }
+    CustomWebView { webview }
 }


### PR DESCRIPTION
This adds the `cargo clippy` linter to the github workflow. I also fixed all warnings created by clippy. 

One comment though: You should consider adding logging support to youp. Seems like there is a bunch of places where return values are not checked. Youp should at least log a warning when things go wrong. 