### PR TITLE
Flatpak: limit the access to local files

### DIFF
--- a/build-aux/com.gigitux.youp.json
+++ b/build-aux/com.gigitux.youp.json
@@ -13,7 +13,13 @@
     "--socket=session-bus",
     "--device=dri",
     "--socket=pulseaudio",
-    "--filesystem=home",
+    "--filesystem=xdg-desktop",
+    "--filesystem=xdg-documents",
+    "--filesystem=xdg-download",
+    "--filesystem=xdg-music",
+    "--filesystem=xdg-pictures",
+    "--filesystem=xdg-public-share",
+    "--filesystem=xdg-videos",
     "--talk-name=org.kde.StatusNotifierWatcher"
   ],
   "build-options": {


### PR DESCRIPTION
* Instead of allowing access to the whole user folder, limit the
  sandboxed app to only access general user content folders (e.g.
  Downloads, Documents, Videos, Pictures). Deny app's access to
  user settings or other sensitive folders.